### PR TITLE
Add sitemaps #39

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,8 @@ gem 'omniauth_openid_connect'
 gem "wicked_pdf", "~> 2.1"
 gem "dalli", "~> 3.2"
 
+gem 'decidim-sitemaps'
+
 group :development, :test do
   gem "byebug", "~> 11.0", platform: :mri
 

--- a/config/initializers/sitemap.rb
+++ b/config/initializers/sitemap.rb
@@ -1,0 +1,4 @@
+Decidim::Sitemaps.configure do |config|
+    config.users = { enabled: false, changefreq: "daily", priority: 0.5 }
+    config.proposals = { enabled: true, changefreq: "daily", priority: 0.5, scopes: [:published] }
+  end


### PR DESCRIPTION
This is a PR to add sitemaps to the Decidim instance using https://git.fpfis.eu/future-of-europe/digit-cofe-libraries/digit-cofe-sitemap which fixes #39 