### PR TITLE
fix: duplicate migration files in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,8 @@ RUN apt-get update -yq \
   && bundle config set with "production" \
   && bundle config set no_cache "true" \
   && bundle config set deployment "false" \
-  && rm -rf vendor Gemfile.lock
+  && rm -rf vendor Gemfile.lock \
+  && rm -rf db/migrate/*
 
 COPY ./contrib/01_mautic_entrypoint /usr/local/share/docker-entrypoint.d/01_mautic_entrypoint
 COPY --chown=decidim:decidim ./contrib/nginx/nginx.conf /etc/nginx/nginx.conf


### PR DESCRIPTION
The original image `git.octree.ch:4567/decidim/vocacity/system/decidim-0.27` have already migrations files in it. With this PR, we remove the migration from this first image, and replace them with the one present in our mautic repository. 

This will fix the following error on development redeploy, while doing a `rails db:migrate`: 
```
rails aborted!
ActiveRecord::DuplicateMigrationNameError:

Multiple migrations have the name DeviseCreateDecidimUsers.

Tasks: TOP => db:migrate
```