### PR TITLE
fix: nginx proxy buffer size

### DIFF
--- a/contrib/nginx/nginx.conf
+++ b/contrib/nginx/nginx.conf
@@ -34,7 +34,7 @@ http {
 
     connection_pool_size 256;
     client_header_buffer_size 1k;
-    large_client_header_buffers 4 2k;
+    large_client_header_buffers 4 16k;
     request_pool_size 4k;
 
     gzip on;
@@ -89,7 +89,10 @@ http {
 
         location @rails {
             proxy_http_version 1.1;
-            proxy_buffering off;
+            proxy_buffering on;
+	    proxy_buffer_size 128k;
+	    proxy_buffers     4 256k;
+	    proxy_busy_buffers_size 256k;
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection "upgrade";
             proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
Fix for bad gateway error when the headers are too large.
Modification in Nginx allowing larger response headers from Rails.
Fixes #89 